### PR TITLE
Fix Standalone miner client.reconnect

### DIFF
--- a/src/libstratum/StratumClient.cpp
+++ b/src/libstratum/StratumClient.cpp
@@ -306,8 +306,10 @@ void StratumClient<Miner, Job, Solution>::processReponse(const Object& responseO
             const Value& valParams = find_value(responseObject, "params");
             if (valParams.type() == array_type) {
                 const Array& params = valParams.get_array();
-                p_active->host = params[0].get_str();
-                p_active->port = params[1].get_str();
+                if (params.size() > 0) {
+                    p_active->host = params[0].get_str();
+                    p_active->port = params[1].get_str();
+                }
                 // TODO: Handle wait time
                 LogS("Reconnection requested\n");
                 reconnect();

--- a/src/libstratum/StratumClient.cpp
+++ b/src/libstratum/StratumClient.cpp
@@ -306,8 +306,8 @@ void StratumClient<Miner, Job, Solution>::processReponse(const Object& responseO
             const Value& valParams = find_value(responseObject, "params");
             if (valParams.type() == array_type) {
                 const Array& params = valParams.get_array();
-                m_primary.host = params[0].get_str();
-                m_primary.port = params[1].get_str();
+                p_active->host = params[0].get_str();
+                p_active->port = params[1].get_str();
                 // TODO: Handle wait time
                 LogS("Reconnection requested\n");
                 reconnect();


### PR DESCRIPTION
commit 1: change just the active (session) settings, not the primary/failover settings
commit 2: stratum spec allow empty array: reconnect to current host/port: https://github.com/str4d/zips/blob/142c7fda313bc65c4bf95fd4023573e3a2dff67e/drafts/str4d-stratum/draft1.rst#clientreconnect
