### PR TITLE
Fix getblocksubsidy suggestions

### DIFF
--- a/src/consensus/params.cpp
+++ b/src/consensus/params.cpp
@@ -194,7 +194,7 @@ namespace Consensus {
 
         const auto expectedRecipients = params.FundingPeriodIndex(startHeight, endHeight - 1) + 1;
         if (expectedRecipients > recipients.size()) {
-            return FundingStreamError::INSUFFICIENT_ADDRESSES;
+            return FundingStreamError::INSUFFICIENT_RECIPIENTS;
         }
 
         // Lockbox output periods must not start before NU6
@@ -221,8 +221,8 @@ namespace Consensus {
                     throw std::runtime_error("Canopy network upgrade not active at funding stream start height.");
                 case FundingStreamError::ILLEGAL_RANGE:
                     throw std::runtime_error("Illegal start/end height combination for funding stream.");
-                case FundingStreamError::INSUFFICIENT_ADDRESSES:
-                    throw std::runtime_error("Insufficient payment addresses to fully exhaust funding stream.");
+                case FundingStreamError::INSUFFICIENT_RECIPIENTS:
+                    throw std::runtime_error("Insufficient recipient identifiers to fully exhaust funding stream.");
                 case FundingStreamError::NU6_NOT_ACTIVE:
                     throw std::runtime_error("NU6 network upgrade not active at lockbox period start height.");
                 default:

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -134,7 +134,7 @@ extern const struct FSInfo FundingStreamInfo[];
 enum FundingStreamError {
     CANOPY_NOT_ACTIVE,
     ILLEGAL_RANGE,
-    INSUFFICIENT_ADDRESSES,
+    INSUFFICIENT_RECIPIENTS,
     NU6_NOT_ACTIVE,
 };
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -115,39 +115,40 @@ public:
     }
 
     CAmount SetFoundersRewardAndGetMinerValue(sapling::Builder& saplingBuilder) const {
-        auto block_subsidy = chainparams.GetConsensus().GetBlockSubsidy(nHeight);
+        const auto& consensus = chainparams.GetConsensus();
+        const auto block_subsidy = consensus.GetBlockSubsidy(nHeight);
         auto miner_reward = block_subsidy; // founders' reward or funding stream amounts will be subtracted below
 
         if (nHeight > 0) {
             if (chainparams.GetConsensus().NetworkUpgradeActive(nHeight, Consensus::UPGRADE_CANOPY)) {
-                auto fundingStreamElements = chainparams.GetConsensus().GetActiveFundingStreamElements(
-                    nHeight,
-                    block_subsidy);
+                const auto fundingStreams = consensus.GetActiveFundingStreams(nHeight);
 
                 LogPrint("pow", "%s: Constructing funding stream outputs for height %d", __func__, nHeight);
-                for (Consensus::FundingStreamElement fselem : fundingStreamElements) {
-                    miner_reward -= fselem.second;
-                    examine(fselem.first, match {
+                for (const auto& [fsinfo, fs] : fundingStreams) {
+                    const auto amount = fsinfo.Value(block_subsidy);
+                    miner_reward -= amount;
+
+                    examine(fs.Recipient(consensus, nHeight), match {
                         [&](const libzcash::SaplingPaymentAddress& pa) {
-                            LogPrint("pow", "%s: Adding Sapling funding stream output of value %d", __func__, fselem.second);
+                            LogPrint("pow", "%s: Adding Sapling funding stream output of value %d", __func__, amount);
                             saplingBuilder.add_recipient(
                                 {},
                                 pa.GetRawBytes(),
-                                fselem.second,
+                                amount,
                                 libzcash::Memo::ToBytes(std::nullopt));
                         },
                         [&](const CScript& scriptPubKey) {
-                            LogPrint("pow", "%s: Adding transparent funding stream output of value %d", __func__, fselem.second);
-                            mtx.vout.emplace_back(fselem.second, scriptPubKey);
+                            LogPrint("pow", "%s: Adding transparent funding stream output of value %d", __func__, amount);
+                            mtx.vout.emplace_back(amount, scriptPubKey);
                         },
                         [&](const Consensus::Lockbox& lockbox) {
-                            LogPrint("pow", "%s: Noting lockbox output of value %d", __func__, fselem.second);
+                            LogPrint("pow", "%s: Noting lockbox output of value %d", __func__, amount);
                         }
                     });
                 }
             } else if (nHeight <= chainparams.GetConsensus().GetLastFoundersRewardBlockHeight(nHeight)) {
                 // Founders reward is 20% of the block subsidy
-                auto vFoundersReward = miner_reward / 5;
+                const auto vFoundersReward = miner_reward / 5;
                 // Take some reward away from us
                 miner_reward -= vFoundersReward;
                 // And give it to the founders


### PR DESCRIPTION
* Rename `INSUFFICIENT_ADDRESSES` to `INSUFFICIENT_RECIPIENTS`.
* `sapling::Builder`: add funding stream outputs in a more predictable order.
* Simplify `GetActiveFundingStreamElements`.

Note that `GetActiveFundingStreamElements` is used by consensus, so this requires consensus-level review.
